### PR TITLE
fix: map athlete to passport profile according to spec

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -69,7 +69,11 @@ Strategy.prototype.userProfile = function (accessToken, done) {
       const profile = { provider: 'strava' };
       if (json.id) {
         profile.id = json.id;
-        profile.fullName = `${json.firstname} ${json.lastname}`;
+        profile.displayName = `${json.firstname} ${json.lastname}`;
+        
+        // This should be deprecated in future release.
+        profile.fullName = profile.displayName;
+        
         profile.name = {
           familyName: json.lastname,
           givenName: json.firstname,
@@ -78,7 +82,12 @@ Strategy.prototype.userProfile = function (accessToken, done) {
           { value: json.profile },
           { value: json.profile_medium },
         ];
-        profile.token = accessToken;
+        
+        if (json.sex === 'M') {
+          profile.gender = 'male';
+        } else if (json.sex === 'F') {
+          profile.gender = 'female';
+        }
       }
 
       profile._raw = body;


### PR DESCRIPTION
The current mapping does not conform to the spec outlined by passport.

added `displayName` and kept fullName to avoid a breaking change.  It should be removed.
added gender based on values in spec

https://developers.strava.com/docs/reference/#api-models-DetailedAthlete
   gender:  The gender of this contact.  Service Providers SHOULD return
      one of the following Canonical Values, if appropriate: "male",
      "female", or "undisclosed", and MAY return a different value if it
      is not covered by one of these Canonical Values.

http://www.passportjs.org/docs/profile/

https://tools.ietf.org/html/draft-smarr-vcarddav-portable-contacts-00